### PR TITLE
Added instructions on how to install empv.el through straight

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,6 +16,15 @@ First, you need to install [[https://mpv.io][mpv]], go check out it's installati
              :repo "isamert/empv.el"))
 #+end_src
 
+Alternatively, you can use the [[https://github.com/raxod502/straight.el][straight]] package manager:
+#+begin_src elisp
+  (use-package empv
+    :straight (empv
+	       :type git
+	       :host github
+	       :repo "isamert/empv.el"))
+#+end_src
+
 Another option is just downloading =empv.el= file and putting into your =load-path=, afterwards you can simply do the following in your =init.el=:
 
 #+begin_src elisp


### PR DESCRIPTION
I thought I'd add straight to the `README.org` installation instructions, since it makes it easier to pin specific branches and commits, it makes it easier to contribute to the project, and it's also becoming more popular in the doom-emacs ecosystem.