### PR TITLE
Display better names for urls in playlist

### DIFF
--- a/empv.el
+++ b/empv.el
@@ -676,7 +676,9 @@ finishes."
       (empv-flipcall #'assoc-string results)
       (cdr)
       (alist-get (if is-video 'videoId 'playlistId))
-      (format "https://youtube.com/%s=%s" (if is-video "watch?v" "playlist?list")))))
+      (format "https://youtube.com/%1$s=%3$s # %2$s"
+	      (if is-video "watch?v" "playlist?list")
+	      selected))))
 
 (cl-defun empv--completing-read (prompt candidates &key category sort)
   "`completing-read' wrapper.


### PR DESCRIPTION
If you add a youtube url it will only show it url in the playlist, not
the title. With this change it will show: `$url # $title`.

This works because mpv discards what is beyond the `#` (source
https://github.com/mpv-player/mpv/issues/7438#issuecomment-601940408).
Tried to do something in the mpv end, but didn't find anything. My
goal was to make `playlist` display the `media-title` instead of the
`filename` which is the url in these cases, but apparently is not
possible to do.

Also, when a playlist url is loaded, instead of a video one, this is
not a problem, since the titles are correctly loaded to the playlist.

Others solutions (at least that I could think of) involve doing more
http request, using for example youtube-dl just to retrieve the
titles, but I don't think that's a good idea.