### PR TITLE
adding vertico as a dependency

### DIFF
--- a/empv.el
+++ b/empv.el
@@ -32,6 +32,7 @@
 (require 'map)
 (require 'json)
 (require 'url)
+(require 'vertico)
 
 (defgroup empv nil
   "A media player for Emacs"


### PR DESCRIPTION
`empv--completing-read` relies on `vertico-sort-function`, but vertico was not required.