### PR TITLE
Add f.el as dependency

### DIFF
--- a/empv.el
+++ b/empv.el
@@ -47,6 +47,7 @@
 (require 'consult nil t)
 (require 'compat)
 (require 'iimage)
+(require 'f)
 (eval-when-compile
   (require 'subr-x))
 


### PR DESCRIPTION
This adds `f.el` requiring since `f-dirname` and `f-filename` are used.