### PR TITLE
Add support for passing multiple URIs when starting mpv

### DIFF
--- a/empv.el
+++ b/empv.el
@@ -604,13 +604,13 @@ the result.
 
 ;;; Process primitives
 
-(defun empv--make-process (&optional uri)
-  "Create the MPV process with given URI."
+(defun empv--make-process (&rest uris)
+  "Create the MPV process with given URIs."
   (setq empv--process
         (make-process :name "empv-process"
                       :buffer nil
-                      :command (if uri
-                                   `(,empv-mpv-binary ,@empv-mpv-args ,uri)
+                      :command (if uris
+                                   `(,empv-mpv-binary ,@empv-mpv-args ,@uris)
                                  `(,empv-mpv-binary ,@empv-mpv-args)))))
 
 (defun empv--make-network-process ()
@@ -768,12 +768,12 @@ URI might be a string or a list of strings."
         (empv--display-event "%s" title)
         (puthash (empv--clean-uri .path) title empv--media-title-cache)))))
 
-(defun empv-start (&optional uri)
-  "Start mpv using `empv-mpv-command' with given URI."
+(defun empv-start (&rest uris)
+  "Start mpv using `empv-mpv-command' with given URIs."
   (interactive)
   (unless (empv--running?)
     (empv--dbg "Starting MPV.")
-    (empv--make-process uri)
+    (apply #'empv--make-process uris)
     (empv--make-network-process)
     (empv-observe 'metadata #'empv--handle-metadata-change)
     (run-hooks 'empv-init-hook)))


### PR DESCRIPTION
Being able to start empv with more than one file loaded, as you can do using mpv directly, can be really useful.
The other option is to call repeatedly empv-enqueue and I find that a little cumbersome.
