### PR TITLE
Add remote resource playback via SFTP for SSH (Issue #88)

### DIFF
--- a/empv.el
+++ b/empv.el
@@ -1741,17 +1741,22 @@ The display format is determined by the
 (defun empv--find-files-1 (path extensions &optional depth)
   "Find files with given EXTENSIONS under given PATH.
 PROMPT is shown when `completing-read' is called."
-  (let ((default-directory path))
+  (let ((default-directory path)
+        (is-remote (file-remote-p path)))
     (thread-last
       extensions
       (mapcar (lambda (ext) (format "-e '%s' " ext)))
       (string-join)
-      (concat (format "%s . --absolute-path --max-depth %s "
+      (concat (format "%s . --absolute-path --max-depth %s -c never "
                       empv-fd-binary
                       (or depth empv-max-directory-search-depth)))
       (shell-command-to-string)
       (empv--flipcall #'split-string "\n")
-      (empv--seq-init))))
+      (empv--seq-init)
+      (mapcar #'(lambda (s)
+             (if is-remote
+                 (concat is-remote s)
+               s))))))
 
 (defun empv--find-files (path extensions &optional depth)
   "Like `empv--find-files-1' but PATH can be a list."

--- a/empv.el
+++ b/empv.el
@@ -1289,7 +1289,10 @@ See this[1] for more information.
 This is just a simple wrapper around `empv-play' that displays
 `find-file' dialog if called interactively."
   (interactive "fPlay file: ")
-  (empv-play-or-enqueue (expand-file-name path)))
+  (thread-last path
+               expand-file-name
+               empv--tramp-to-sftp-uri
+               empv-play-or-enqueue))
 
 ;;;###autoload
 (defun empv-play-directory (path)
@@ -1303,6 +1306,7 @@ see `empv-base-directory'."
   (thread-last
     (empv--find-files path (append empv-audio-file-extensions empv-video-file-extensions) 1)
     (mapcar (lambda (it) (expand-file-name it path)))
+    (mapcar (lambda (it) (empv--tramp-to-sftp-uri it)))
     (empv-play-or-enqueue)))
 
 ;;;###autoload

--- a/empv.el
+++ b/empv.el
@@ -915,7 +915,10 @@ documentation."
       (list
        :uri uri
        :title (gethash uri empv--media-title-cache
-                       (or fallback (abbreviate-file-name uri)))))))
+                       (or fallback (abbreviate-file-name
+                                     (if (file-remote-p uri)
+                                         (file-remote-p uri 'localname)
+                                       uri))))))))
 
 ;;;; Handlers
 
@@ -1751,10 +1754,7 @@ PROMPT is shown when `completing-read' is called."
       (shell-command-to-string)
       (empv--flipcall #'split-string "\n")
       (empv--seq-init)
-      (mapcar #'(lambda (s)
-             (if is-remote
-                 (concat is-remote s)
-               s))))))
+      (mapcar #'(lambda (s) (if is-remote (concat is-remote s) s))))))
 
 (defun empv--find-files (path extensions &optional depth)
   "Like `empv--find-files-1' but PATH can be a list."

--- a/empv.el
+++ b/empv.el
@@ -1240,6 +1240,7 @@ enqueued and the first one starts playing."
        (empv-resume))
     (when (file-exists-p uri)
       (setq uri (expand-file-name uri)))
+    (setq uri (empv--tramp-to-sftp-uri uri))
     (if (empv--running?)
         (empv--cmd-seq
          ('loadfile (list uri 'append))
@@ -1289,10 +1290,7 @@ See this[1] for more information.
 This is just a simple wrapper around `empv-play' that displays
 `find-file' dialog if called interactively."
   (interactive "fPlay file: ")
-  (thread-last path
-               expand-file-name
-               empv--tramp-to-sftp-uri
-               empv-play-or-enqueue))
+  (empv-play-or-enqueue (expand-file-name path)))
 
 ;;;###autoload
 (defun empv-play-directory (path)
@@ -1306,7 +1304,6 @@ see `empv-base-directory'."
   (thread-last
     (empv--find-files path (append empv-audio-file-extensions empv-video-file-extensions) 1)
     (mapcar (lambda (it) (expand-file-name it path)))
-    (mapcar (lambda (it) (empv--tramp-to-sftp-uri it)))
     (empv-play-or-enqueue)))
 
 ;;;###autoload
@@ -1473,6 +1470,7 @@ URI might be a list of URIs, then they are all enqueued in order."
       (seq-do #'empv-enqueue uri)
     (when (string-prefix-p "~/" uri)
       (setq uri (expand-file-name uri)))
+    (setq uri (empv--tramp-to-sftp-uri uri))
     (empv--cmd 'loadfile `(,uri append-play))
     (empv--display-event "Enqueued %s" uri)))
 

--- a/empv.el
+++ b/empv.el
@@ -831,6 +831,25 @@ Taken from transient.el.
 
 ;;;; Utility: Url/Path/Metadata
 
+(defun empv--tramp-to-sftp-uri (uri)
+  "Given a URI from locating a resource via tramp, convert it into a URI that MPV can stream.
+If URI does not point to a remote resource, return as-is.
+
+NOTE: Only supports SSH/SSHX methods on tramp."
+  (if (not (file-remote-p uri))
+      uri
+    (let ((method (file-remote-p uri 'method))
+          (user (file-remote-p uri 'user))
+          (host (file-remote-p uri 'host))
+          (localname (file-remote-p uri 'localname)))
+      (if (not (member method (list "ssh" "sshx")))
+          (user-error "empv: method %s is not supported for playback." method))
+      (format "sftp://%s%s"
+              (if user
+                  (format "%s@%s" user host)
+                host)
+              localname))))
+
 (defun empv--clean-uri (it)
   (car (split-string it empv--title-sep)))
 


### PR DESCRIPTION
Implements feature request #88.  Re-opened from PR #93 for personal
branch admin purposes.

Many things to still iron out and test (not least the error call in
empv--tramp-to-sftp-uri which is certainly NOT graceful), but this
change should allow one to:

- select and play a video/audio file from some remote host via
  find-file
- select and queue all media files in a remote path
- add remote paths to empv-video-dir and empv-audio-dir AND be able to
  play/enqueue files from them like your other directories

Hope to hear from you soon regarding any queries or problems with my
code.

Notes from PR #93:

- TRAMP is awful when you're unable to connect to a remote host
  i.e. due to network issues or lack of auth - Emacs freezes when
  trying to select a file via empv-play-file or empv-play-video when
  empv-video-dir contains a remote host Seems to be a general issue
  with TRAMP, though may be possible to apply a bandaid on this.

- If a playlist contains some remote files is saved to disk, mpv will
  refuse to play them unless load-unsafe-playlists is set - one may
  set it for all mpv sessions by putting it in mpv.conf so I don't
  think any changes on the codebase are necessary
