### PR TITLE
Add function to load playlists from empv-playlist-dir

### DIFF
--- a/empv.el
+++ b/empv.el
@@ -1553,8 +1553,8 @@ Example:
   (empv--playlist-apply #'empv--playlist-save-to-file filename))
 
 ;;;###autoload
-(defun empv-playlist-load-from-file (&optional filename)
-  "Load a playlist from EMPV-PLAYLIST-DIR."
+(defun empv-playlist-load-from-file ()
+  "Load a playlist from `empv-playlist-dir'."
   (interactive)
   (empv-play-or-enqueue
    (empv--select-file "Select a playlist file:" empv-playlist-dir '("m3u"))))
@@ -3167,7 +3167,8 @@ Also see `empv-search-prefix'."
         (url-unhex-string)
         (funcall (lambda (it) (setq url it) it))
         (empv--request-raw-sync)
-        (string-replace "" "")
+        (string-replace "
+" "")
         ;; Replace newlines so that regexes can work
         (string-replace "\n" "<newline>")
         ;; FIXME: The resulting string may be too long and regexes may
@@ -3195,7 +3196,8 @@ Also see `empv-search-prefix'."
            ("</div>" . "")
            ("\\" . "")
            ("<newline>" . "\n")
-           ("" . "\n")
+           ("
+" . "\n")
            ("\"" . "")
            ("&quot;" . "\"")
            ("&#x27;" . "'")

--- a/empv.el
+++ b/empv.el
@@ -558,6 +558,7 @@ Maximum possible value is 500. "
     (define-key map "C" 'empv-playlist-clear)
     (define-key map "n" 'empv-playlist-next)
     (define-key map "N" 'empv-playlist-prev)
+    (define-key map "L" 'empv-playlist-load-from-file)
     (put 'empv-playlist-next 'repeat-map 'empv-map)
     (put 'empv-playlist-prev 'repeat-map 'empv-map)
 

--- a/empv.el
+++ b/empv.el
@@ -1551,6 +1551,13 @@ Example:
         fname))))
   (empv--playlist-apply #'empv--playlist-save-to-file filename))
 
+;;;###autoload
+(defun empv-playlist-load-from-file (&optional filename)
+  "Load a playlist from EMPV-PLAYLIST-DIR."
+  (interactive)
+  (empv-play-or-enqueue
+   (empv--select-file "Select a playlist file:" empv-playlist-dir '("m3u"))))
+
 ;;;; Interactive - Misc
 
 (defun empv--format-clock (it)


### PR DESCRIPTION
`empv-playlist-load-from-file`: asks user to select a playlist from
empv-playlist-dir, then plays/enqueues it.  Works as expected, only
adds code so no effect on other functionality.

NOTE: Only m3u extensions are supported when searching for playlists
in the directory, as per precedent set in `empv-playlist-save-to-file`.
