### PR TITLE
Convert request_id to a number before json encoding

### DIFF
--- a/empv.el
+++ b/empv.el
@@ -1064,9 +1064,9 @@ happens."
           (msg (json-encode
                 (if event?
                     `((command . (,(seq-first command) ,(string-to-number request-id) ,@(seq-rest command)))
-                      (request_id . ,request-id))
+                      (request_id . ,(string-to-number request-id)))
                   `((command . ,command)
-                    (request_id . ,request-id))))))
+                    (request_id . ,(string-to-number request-id)))))))
      (when callback
        (map-put! empv--callback-table request-id (list :fn callback :event? event?)))
      (process-send-string empv--network-process (format "%s\n" msg))


### PR DESCRIPTION
For quite some time mpv requires (even though it isn't enforced and it just prints a warning) the field request_id of ipc messages to be an integer (see https://github.com/mpv-player/mpv/commit/fc574ee5634112c21ee4b61d8f9b7517ec3192a2).

In theory, although relatively improbable at this point, this requirement could get enforced in a future release and even if this never happens mpv prints a warn for every offending ipc message resulting in a bunch of noise in the log.

The easiest path to solve this problem by just converting the id before calling `json-encode`.
The other option is to change `empv--new-request-id` and make it return an number instead of a string.

Not being sure if it's preferable to keep the internal string representation for request_id, I opted for the first one.
If the second option sound better let me know and I can work on it.